### PR TITLE
implement KeyReader from UPS

### DIFF
--- a/webapp/src/main/java/net/opentsdb/horizon/secrets/UpsKeyReader.java
+++ b/webapp/src/main/java/net/opentsdb/horizon/secrets/UpsKeyReader.java
@@ -1,0 +1,48 @@
+package net.opentsdb.horizon.secrets;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import java.nio.charset.StandardCharsets;
+
+public class UpsKeyReader extends KeyReader {
+
+    final String SPLITTER = ":";
+    final String VCAP_SERVICES = "VCAP_SERVICES";
+    final String USER_PROVIDED = "user-provided";
+    final String CREDENTIALS = "credentials";
+
+    @Override
+    protected byte[] readSecret(String key) throws KeyException {
+        String[] values = key.split(SPLITTER);
+        String upsName = values[0];
+        String secretName = values[1];
+
+        String secretValue = "";
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(System.getenv(VCAP_SERVICES));
+            JsonNode upsList = root.get(USER_PROVIDED);
+
+            JsonNode targetUps = null;
+            for(JsonNode ups : upsList) {
+                if(ups.get("name").asText().equals(upsName)) {
+                    targetUps = ups;
+                    break;
+                }
+            }
+            if(targetUps == null) {
+                throw new KeyException(String.format("UPS(name=%s) is not found", upsName));
+            }
+            secretValue = targetUps.get(CREDENTIALS).get(secretName).asText();
+        } catch (JsonProcessingException e) {
+            throw new KeyException(String.format("json parse error"));
+        } catch (NullPointerException e) {
+            throw new KeyException(String.format("Secret(%s) is not found", secretName));
+        }
+
+        return secretValue.getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/webapp/src/main/java/net/opentsdb/horizon/secrets/UpsKeyReaderFactory.java
+++ b/webapp/src/main/java/net/opentsdb/horizon/secrets/UpsKeyReaderFactory.java
@@ -1,0 +1,10 @@
+package net.opentsdb.horizon.secrets;
+
+import java.util.Map;
+
+public class UpsKeyReaderFactory implements KeyReaderFactory<UpsKeyReader> {
+    @Override
+    public UpsKeyReader createKeyReader(Map<String, Object> config) {
+        return new UpsKeyReader();
+    }
+}


### PR DESCRIPTION
### 概要
Secret情報を取得する際に、UPSから取得できるようにする
設定ファイルに下記のようなフォーマットで記載することとする

`KEY:<UPS名>:<シークレット名>`

### 使い方

Configファイルに下記のような設定を行う
```
dbConfig:
  dbKey: KEY:UpsInstance:password_key
~~~~
applicationConfig:
  keyReaderFactoryClassName: net.opentsdb.horizon.secrets.UpsKeyReaderFactory
```